### PR TITLE
CTCTRADERS-1157: Add message summary endpoint

### DIFF
--- a/app/controllers/MessagesSummaryController.scala
+++ b/app/controllers/MessagesSummaryController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+import controllers.actions.AuthenticatedGetDepartureForReadActionProvider
+import javax.inject.Inject
+import models.DepartureId
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import services.MessageSummaryService
+import uk.gov.hmrc.play.bootstrap.controller.BackendController
+
+class MessagesSummaryController @Inject()(
+  authenticateForRead: AuthenticatedGetDepartureForReadActionProvider,
+  messageSummaryService: MessageSummaryService,
+  cc: ControllerComponents
+) extends BackendController(cc) {
+
+  def messagesSummary(departureId: DepartureId): Action[AnyContent] = authenticateForRead(departureId) {
+    implicit request =>
+      val messageSummary = messageSummaryService.messagesSummary(request.departure)
+
+      Ok(Json.toJsObject(messageSummary))
+  }
+
+}

--- a/app/models/MessagesSummary.scala
+++ b/app/models/MessagesSummary.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json._
+
+case class MessagesSummary(departure: Departure, declaration: MessageId, declarationRejection: Option[MessageId] = None, mrnAllocated: Option[MessageId] = None)
+
+object MessagesSummary {
+
+  implicit val writes: OWrites[MessagesSummary] =
+    OWrites[MessagesSummary] {
+      case MessagesSummary(departure, declaration, declarationRejection, mrnAllocated) =>
+        Json
+          .obj(
+            "departureId" -> departure.departureId,
+            "messages" -> Json.obj(
+              MessageType.DepartureDeclaration.code -> controllers.routes.MessagesController.getMessage(departure.departureId, declaration).url,
+              MessageType.DeclarationRejected.code  -> declarationRejection.map(controllers.routes.MessagesController.getMessage(departure.departureId, _).url),
+              MessageType.MrnAllocated.code         -> mrnAllocated.map(controllers.routes.MessagesController.getMessage(departure.departureId, _).url)
+            )
+          )
+          .filterNulls
+    }
+}

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import play.api.libs.json._
+
+package object models {
+  implicit class RichJsObject(obj: JsObject) {
+
+    def map(f: (String, JsValue) => (String, JsValue)): JsObject =
+      JsObject(obj.fields.map(f.tupled))
+
+    def filter(f: (String, JsValue) => Boolean): JsObject =
+      JsObject(obj.fields.filter(f.tupled))
+
+    def filterNot(f: (String, JsValue) => Boolean): JsObject =
+      JsObject(obj.fields.filterNot(f.tupled))
+
+    def filterNulls: JsObject =
+      map {
+        case (k, v: JsObject) =>
+          k -> v.filterNulls
+        case (k, v: JsArray) =>
+          k -> v.filterNulls
+        case (k, v) =>
+          k -> v
+      }.filterNot((_, v) => v == JsNull || v == Json.obj() || v == JsArray())
+  }
+
+  implicit class RichJsArray(arr: JsArray) {
+
+    def map(f: JsValue => JsValue): JsArray =
+      JsArray(arr.value.map(f))
+
+    def filter(f: JsValue => Boolean): JsArray =
+      JsArray(arr.value.filter(f))
+
+    def filterNot(f: JsValue => Boolean): JsArray =
+      JsArray(arr.value.filterNot(f))
+
+    def filterNulls: JsArray =
+      map {
+        case v: JsObject => v.filterNulls
+        case v: JsArray  => v.filterNulls
+        case v           => v
+      }.filterNot(v => v == JsNull || v == Json.obj() || v == JsArray())
+  }
+}

--- a/app/services/MessageSummaryService.scala
+++ b/app/services/MessageSummaryService.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+import cats.data.NonEmptyList
+import cats.data.Reader
+import models.MessageType.DeclarationRejected
+import models.MessageType.DepartureDeclaration
+import models.MessageType.MrnAllocated
+import models.MessagesSummary
+import models._
+
+class MessageSummaryService {
+
+  import MessageSummaryService._
+
+  def messagesSummary(departure: Departure): MessagesSummary =
+    (for {
+      declaration          <- declarationMessage
+      declarationRejection <- declarationRejectionMessage
+      mrnAllocated         <- mrnAllocatedMessage
+      //TODO: Other messages need adding
+    } yield {
+      MessagesSummary(departure, declaration._2, declarationRejection.map(_._2), mrnAllocated.map(_._2))
+    }).run(departure)
+
+  private[services] val declarationMessage: Reader[Departure, (Message, MessageId)] =
+    Reader[Departure, (Message, MessageId)](_.messagesWithId match {
+      case NonEmptyList(declaration, Nil) =>
+        declaration
+
+      case NonEmptyList(declaration, _ :: Nil) =>
+        declaration
+
+      case NonEmptyList((msg @ MessageWithStatus(_, DepartureDeclaration, _, _, _), id), tail) =>
+        // This is a workaround since we cannot infer the type of head
+        // to be (MovementMessageWithStatus, MessageId) using @ in the pattern match
+        val head: (MessageWithStatus, MessageId) = (msg, id)
+
+        tail
+          .foldLeft(NonEmptyList.of(head))({
+            case (acc, (m @ MessageWithStatus(_, DepartureDeclaration, _, _, _), mid)) => acc :+ Tuple2(m, mid)
+            case (acc, _)                                                              => acc
+          })
+          .toList
+          .maxBy(_._1.messageCorrelationId)
+
+      case NonEmptyList((msg, _), _) =>
+        // Unreachable but unprovable
+        throw new RuntimeException(
+          "Reached an invalid state when summarizing Declaration . " +
+            "Expected the first message of the movement to be MovementMessageWithStatus with an DepartureDeclaration, " +
+            s"but got ${msg.getClass} that contained a ${msg.messageType.code}"
+        )
+    })
+
+  private[services] val mrnAllocatedMessage: Reader[Departure, Option[(Message, MessageId)]] =
+    Reader[Departure, Option[(Message, MessageId)]] {
+      departure =>
+        val mrnAllocated = getLatestMessageWithoutStatus(departure.messagesWithId)(MrnAllocated)
+
+        val mrnAllocatedCount = mrnAllocated.length
+
+        if (mrnAllocatedCount > 0 && departureDeclarationCount(departure.messages) > 0)
+          Some(mrnAllocated.maxBy(_._1.messageCorrelationId))
+        else
+          None
+    }
+
+  private[services] val declarationRejectionMessage: Reader[Departure, Option[(Message, MessageId)]] =
+    Reader[Departure, Option[(Message, MessageId)]] {
+      departure =>
+        val rejectionNotifications = getLatestMessageWithoutStatus(departure.messagesWithId)(DeclarationRejected)
+
+        val rejectionNotificationCount = rejectionNotifications.length
+
+        if (rejectionNotificationCount > 0 && departureDeclarationCount(departure.messages) == rejectionNotificationCount)
+          Some(rejectionNotifications.maxBy(_._1.messageCorrelationId))
+        else
+          None
+    }
+}
+
+object MessageSummaryService {
+  private val departureDeclarationCount: NonEmptyList[Message] => Int = {
+    movementMessages =>
+      movementMessages.toList.count {
+        case MessageWithStatus(_, DepartureDeclaration, _, _, _) => true
+        case _                                                   => false
+      }
+  }
+
+  private val getLatestMessageWithoutStatus: NonEmptyList[(Message, MessageId)] => MessageType => Seq[(MessageWithoutStatus, MessageId)] = {
+    messagesWithId => messageType =>
+      messagesWithId
+        .foldLeft(Seq.empty[(MessageWithoutStatus, MessageId)]) {
+          case (acc, (m @ MessageWithoutStatus(_, `messageType`, _, _), mid)) => acc :+ Tuple2(m, mid)
+          case (acc, _)                                                       => acc
+        }
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,6 +5,8 @@ GET        /movements/departures                                        controll
 
 GET        /movements/departures/:departureId                           controllers.DeparturesController.get(departureId: DepartureId)
 
+
+GET        /movements/departures/:departureId/messages/summary          controllers.MessagesSummaryController.messagesSummary(departureId: DepartureId)
 GET        /movements/departures/:departureId/messages                  controllers.MessagesController.getMessages(departureId: DepartureId)
 POST       /movements/departures/:departureId/messages                  controllers.MessagesController.post(departureId: DepartureId)
 

--- a/test/controllers/MessagesSummaryControllerSpec.scala
+++ b/test/controllers/MessagesSummaryControllerSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+import base.SpecBase
+import controllers.actions.AuthenticatedGetDepartureForReadActionProvider
+import controllers.actions.FakeAuthenticatedGetDepartureForReadActionProvider
+import generators.ModelGenerators
+import models.Departure
+import models.MessageId
+import models.MessagesSummary
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.inject.bind
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers.GET
+import play.api.test.Helpers.contentAsJson
+import play.api.test.Helpers.route
+import play.api.test.Helpers.running
+import play.api.test.Helpers.status
+import play.api.test.Helpers._
+import services.MessageSummaryService
+
+class MessagesSummaryControllerSpec extends SpecBase with ScalaCheckPropertyChecks with ModelGenerators with BeforeAndAfterEach with IntegrationPatience {
+
+  val departure: Departure = arbitrary[Departure].sample.value
+  val departureId          = departure.departureId
+
+  "MessagesSummaryControllerSpec" - {
+
+    "must return" - {
+
+      "return an OK with the message summary when a departure exists" in {
+        val fake        = FakeAuthenticatedGetDepartureForReadActionProvider(departure)
+        val mockService = mock[MessageSummaryService]
+
+        val declarationMessageId         = MessageId.fromMessageIdValue(1).value
+        val declarationRejectedMessageId = MessageId.fromMessageIdValue(2).value
+        val messagesSummary              = MessagesSummary(departure, declarationMessageId, Some(declarationRejectedMessageId))
+
+        when(mockService.messagesSummary(any())).thenReturn(messagesSummary)
+
+        val app =
+          baseApplicationBuilder
+            .overrides(
+              bind[AuthenticatedGetDepartureForReadActionProvider].toInstance(fake),
+              bind[MessageSummaryService].toInstance(mockService)
+            )
+            .build()
+
+        running(app) {
+          val request = FakeRequest(GET, routes.MessagesSummaryController.messagesSummary(departureId).url)
+
+          val result = route(app, request).value
+
+          status(result) mustEqual OK
+          contentAsJson(result) mustEqual Json.toJsObject(messagesSummary)
+        }
+      }
+    }
+  }
+}

--- a/test/controllers/actions/FakeAuthenticatedGetDepartureForReadActionProvider.scala
+++ b/test/controllers/actions/FakeAuthenticatedGetDepartureForReadActionProvider.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+import models.request.DepartureRequest
+import models.Departure
+import models.DepartureId
+import org.scalatest.exceptions.TestFailedException
+import play.api.mvc._
+import play.api.test.Helpers.stubBodyParser
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class FakeAuthenticatedGetDepartureForReadActionProvider(departure: Departure) extends AuthenticatedGetDepartureForReadActionProvider {
+  override def apply(departureId: DepartureId): ActionBuilder[DepartureRequest, AnyContent] =
+    new ActionBuilder[DepartureRequest, AnyContent] {
+      override def parser: BodyParser[AnyContent] = stubBodyParser()
+
+      override def invokeBlock[A](request: Request[A], block: DepartureRequest[A] => Future[Result]): Future[Result] =
+        if (departure.departureId == departureId) {
+          block(DepartureRequest(request, departure))
+        } else {
+          throw new TestFailedException(
+            s"Bad test data setup. DepartureId on the Departure was ${departure.departureId} but expected to retrieve $departureId",
+            0
+          )
+        }
+
+      override protected def executionContext: ExecutionContext = implicitly[ExecutionContext]
+
+    }
+}
+
+object FakeAuthenticatedGetDepartureForReadActionProvider {
+
+  def apply(departure: Departure): FakeAuthenticatedGetDepartureForReadActionProvider =
+    new FakeAuthenticatedGetDepartureForReadActionProvider(departure)
+}

--- a/test/models/MessagesSummarySpec.scala
+++ b/test/models/MessagesSummarySpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+import base.SpecBase
+import generators.ModelGenerators
+import org.scalacheck.Arbitrary
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.Json
+
+class MessagesSummarySpec extends SpecBase with ModelGenerators with ScalaCheckDrivenPropertyChecks {
+
+  private val departure = Arbitrary.arbitrary[Departure].sample.value
+
+  "MessagesSummary" - {
+
+    "return declaration link" in {
+
+      val messageId = 1
+
+      Json.toJson(
+        MessagesSummary(departure, MessageId.fromIndex(0), None, None)
+      ) mustBe Json.obj(
+        "departureId" -> departure.departureId,
+        "messages" ->
+          Json.obj(
+            "IE015" -> s"/transits-movements-trader-at-departure/movements/departures/${departure.departureId.index}/messages/$messageId"
+          )
+      )
+
+    }
+
+    "return declaration rejected link" in {
+
+      val messageId   = 1
+      val rejectionId = 2
+
+      Json.toJson(
+        MessagesSummary(departure, MessageId.fromIndex(0), Some(MessageId.fromIndex(1)), None)
+      ) mustBe Json.obj(
+        "departureId" -> departure.departureId,
+        "messages" ->
+          Json.obj(
+            "IE015" -> s"/transits-movements-trader-at-departure/movements/departures/${departure.departureId.index}/messages/$messageId",
+            "IE016" -> s"/transits-movements-trader-at-departure/movements/departures/${departure.departureId.index}/messages/$rejectionId"
+          )
+      )
+
+    }
+
+    "return mrn allocated link" in {
+
+      val messageId    = 1
+      val rejectionId  = 2
+      val mrnAllocated = 3
+
+      Json.toJson(
+        MessagesSummary(departure, MessageId.fromIndex(0), Some(MessageId.fromIndex(1)), Some(MessageId.fromIndex(2)))
+      ) mustBe Json.obj(
+        "departureId" -> departure.departureId,
+        "messages" ->
+          Json.obj(
+            "IE015" -> s"/transits-movements-trader-at-departure/movements/departures/${departure.departureId.index}/messages/$messageId",
+            "IE016" -> s"/transits-movements-trader-at-departure/movements/departures/${departure.departureId.index}/messages/$rejectionId",
+            "IE028" -> s"/transits-movements-trader-at-departure/movements/departures/${departure.departureId.index}/messages/$mrnAllocated"
+          )
+      )
+
+    }
+  }
+}

--- a/test/services/MessageSummaryServiceSpec.scala
+++ b/test/services/MessageSummaryServiceSpec.scala
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+import base.SpecBase
+import cats.data.NonEmptyList
+import generators.ModelGenerators
+import models.MessageStatus.SubmissionPending
+import models.MessageStatus.SubmissionSucceeded
+import models.MessageType.DeclarationRejected
+import models.MessageType.DepartureDeclaration
+import models.MessageType.MrnAllocated
+import models._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class MessageSummaryServiceSpec extends SpecBase with ModelGenerators with ScalaCheckDrivenPropertyChecks {
+
+  import MessageSummaryServiceSpec.MovementMessagesHelpers._
+
+  def messageGeneratorSent(messageType: MessageType): Gen[MessageWithStatus] = {
+    val message = xml.XML.loadString(s"<${messageType.rootNode}>test</${messageType.rootNode}>")
+    arbitrary[MessageWithStatus].map(_.copy(messageType = messageType, message = message, status = SubmissionPending))
+  }
+
+  def messageGeneratorResponse(messageType: MessageType): Gen[MessageWithoutStatus] = {
+    val message = xml.XML.loadString(s"<${messageType.rootNode}>test</${messageType.rootNode}>")
+    arbitrary[MessageWithoutStatus].map(_.copy(messageType = messageType, message = message))
+  }
+
+  def createMovement(msgs: NonEmptyList[Message]): Gen[Departure] =
+    for {
+      departureMovement <- arbitrary[Departure]
+    } yield departureMovement.copy(messages = msgs)
+
+  private val ie015Gen = messageGeneratorSent(DepartureDeclaration)
+  private val ie016Gen = messageGeneratorResponse(DeclarationRejected)
+  private val ie028Gen = messageGeneratorResponse(MrnAllocated)
+
+  private val service = new MessageSummaryService
+
+  "declarationMessage" - {
+
+    "must return" - {
+
+      "the original IE015 when there have been no other messages" in {
+        forAll(ie015Gen) {
+          ie015 =>
+            forAll(createMovement(NonEmptyList.one(ie015))) {
+              departure =>
+                val (message, messageId) = service.declarationMessage(departure)
+                message mustEqual ie015
+                messageId mustEqual MessageId.fromMessageIdValue(1).value
+            }
+        }
+      }
+
+      "the original IE015 and first IE016 when there is only an IE015 and a IE016" in {
+        forAll(ie015Gen, ie016Gen) {
+          (ie015, ie016) =>
+            forAll(createMovement(NonEmptyList.of(ie015, ie016))) {
+              departure =>
+                val (message, messageId) = service.declarationMessage(departure)
+                message mustEqual ie015
+                messageId mustEqual MessageId.fromMessageIdValue(1).value
+            }
+        }
+      }
+
+      "the new IE015 when there is multiple IE015 messages" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie016Gen.msgCorrId(1), ie015Gen.msgCorrId(2)) {
+          case (ie015Old, ie016, ie015) =>
+            forAll(createMovement(NonEmptyList.of(ie015Old, ie016, ie015))) {
+              departure =>
+                val (message, messageId) = service.declarationMessage(departure)
+                message mustEqual ie015
+                messageId mustEqual MessageId.fromMessageIdValue(3).value
+            }
+        }
+      }
+
+      "the latest IE015 when all IE015 have been rejected" in {
+        val service = new MessageSummaryService
+
+        forAll(ie015Gen.submitted.msgCorrId(1), ie016Gen.msgCorrId(1), ie015Gen.msgCorrId(2), ie016Gen.msgCorrId(2)) {
+          case (ie015Old, ie016Old, ie015, ie016) =>
+            forAll(createMovement(NonEmptyList.of(ie015Old, ie016Old, ie015, ie016))) {
+              departure =>
+                val (message, messageId) = service.declarationMessage(departure)
+                message mustEqual ie015
+                messageId mustEqual MessageId.fromMessageIdValue(3).value
+            }
+        }
+      }
+    }
+  }
+
+  "mrnAllocatedMessage" - {
+
+    "must return" - {
+
+      "None when IE028 does not exit" in {
+        forAll(ie015Gen) {
+          ie015 =>
+            forAll(createMovement(NonEmptyList.one(ie015))) {
+              departure =>
+                service.mrnAllocatedMessage(departure) must not be defined
+            }
+        }
+      }
+
+      "None when IE015 does not exit" in {
+        forAll(ie028Gen) {
+          ie028 =>
+            forAll(createMovement(NonEmptyList.one(ie028))) {
+              departure =>
+                service.mrnAllocatedMessage(departure) must not be defined
+            }
+        }
+      }
+
+      "IE028 when a IE015 and IE028 exist" in {
+        forAll(ie015Gen, ie028Gen) {
+          (ie015, ie028) =>
+            forAll(createMovement(NonEmptyList.of(ie015, ie028))) {
+              departure =>
+                val (message, messageId) = service.mrnAllocatedMessage(departure).value
+
+                message mustEqual ie028
+                messageId mustEqual MessageId.fromMessageIdValue(2).value
+            }
+        }
+      }
+      //This should never happen
+      "latest IE028 when multiple IE015 messages exist" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie028Gen.msgCorrId(2), ie028Gen.msgCorrId(3)) {
+          case (ie015, ie028Old, ie028) =>
+            forAll(createMovement(NonEmptyList.of(ie015, ie028Old, ie028))) {
+              departure =>
+                val (message, messageId) = service.mrnAllocatedMessage(departure).value
+
+                message mustEqual ie028
+                messageId mustEqual MessageId.fromMessageIdValue(3).value
+            }
+        }
+      }
+    }
+  }
+
+  "declarationRejectionMessage" - {
+
+    "must return" - {
+      "None when there are none in the movement" in {
+        forAll(ie015Gen) {
+          ie015 =>
+            forAll(createMovement(NonEmptyList.one(ie015))) {
+              departure =>
+                service.declarationRejectionMessage(departure) must not be defined
+
+            }
+        }
+      }
+
+      "latest IE016 when there is only an IE015 and a IE016" in {
+        forAll(ie015Gen, ie016Gen) {
+          (ie015, ie016) =>
+            forAll(createMovement(NonEmptyList.of(ie015, ie016))) {
+              departure =>
+                val (message, messageId) = service.declarationRejectionMessage(departure).value
+
+                message mustEqual ie016
+                messageId mustEqual MessageId.fromMessageIdValue(2).value
+            }
+        }
+      }
+
+      "None when there has been a rejected declaration and correction" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie016Gen.msgCorrId(1), ie015Gen.msgCorrId(2)) {
+          case (ie015Old, ie016, ie015) =>
+            val messages = NonEmptyList.of(ie015Old, ie016, ie015)
+
+            forAll(createMovement(messages)) {
+              departure =>
+                service.declarationRejectionMessage(departure) must not be defined
+            }
+        }
+      }
+
+      "IE015 when all IE016 have been rejected" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie016Gen.msgCorrId(1), ie015Gen.msgCorrId(2), ie016Gen.msgCorrId(2)) {
+          case (ie015Old, ie016Old, ie015, ie016) =>
+            forAll(createMovement(NonEmptyList.of(ie015Old, ie016Old, ie015, ie016))) {
+              departure =>
+                val (message, messageId) = service.declarationRejectionMessage(departure).value
+
+                message mustEqual ie016
+                messageId mustEqual MessageId.fromMessageIdValue(4).value
+            }
+        }
+      }
+    }
+  }
+
+  "messagesSummary" - {
+
+    "must return" - {
+
+      "initial IE015 and no IE016 when there is only a IE015" in {
+        forAll(ie015Gen) {
+          ie015 =>
+            forAll(createMovement(NonEmptyList.one(ie015))) {
+              departure =>
+                service.messagesSummary(departure) mustEqual MessagesSummary(departure, MessageId.fromMessageIdValue(1).value, None)
+
+            }
+        }
+      }
+
+      "latest IE016 when there is only an IE015 and a IE016" in {
+        forAll(ie015Gen, ie016Gen) {
+          (ie015, IE016) =>
+            val messages = NonEmptyList.of(ie015, IE016)
+
+            forAll(createMovement(messages)) {
+              departure =>
+                val expectedMessageSummary = MessagesSummary(departure, MessageId.fromMessageIdValue(1).value, MessageId.fromMessageIdValue(2))
+
+                service.messagesSummary(departure) mustEqual expectedMessageSummary
+            }
+        }
+      }
+
+      "latest IE016 when there has been an IE015 correction" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie016Gen.msgCorrId(2), ie015Gen.msgCorrId(3)) {
+          case (ie015Old, ie016Old, ie015) =>
+            forAll(createMovement(NonEmptyList.of(ie015Old, ie016Old, ie015))) {
+              departure =>
+                val expectedMessageSummary = MessagesSummary(departure, MessageId.fromMessageIdValue(3).value, None)
+
+                service.messagesSummary(departure) mustEqual expectedMessageSummary
+            }
+        }
+      }
+
+      "IE016 when all IE015 have been rejected" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie016Gen.msgCorrId(2), ie015Gen.msgCorrId(3), ie016Gen.msgCorrId(4)) {
+          case (ie015Old, ie016Old, ie015, ie016) =>
+            forAll(createMovement(NonEmptyList.of(ie015Old, ie016Old, ie015, ie016))) {
+              departure =>
+                val expectedMessageSummary = MessagesSummary(departure, MessageId.fromMessageIdValue(3).value, MessageId.fromMessageIdValue(4))
+
+                service.messagesSummary(departure) mustEqual expectedMessageSummary
+            }
+        }
+
+      }
+
+      "IE015 and IE028" in {
+        forAll(ie015Gen.submitted.msgCorrId(1), ie028Gen.msgCorrId(2)) {
+          case (ie015, ie0028) =>
+            val messages = NonEmptyList.of(ie015, ie0028)
+
+            forAll(createMovement(messages)) {
+              departure =>
+                val expectedMessageSummary =
+                  MessagesSummary(departure, MessageId.fromMessageIdValue(1).value, None, MessageId.fromMessageIdValue(2))
+
+                service.messagesSummary(departure) mustEqual expectedMessageSummary
+            }
+        }
+      }
+    }
+  }
+}
+
+object MessageSummaryServiceSpec {
+
+  object MovementMessagesHelpers {
+
+    implicit class SubmittedOps(movementMessageWithStatus: Gen[MessageWithStatus]) {
+      def submitted: Gen[MessageWithStatus] = movementMessageWithStatus.map(_.copy(status = SubmissionSucceeded))
+    }
+
+    implicit class MessageCorrelationIdOps(movementMessageWithStatus: Gen[MessageWithStatus]) {
+      def msgCorrId(value: Int): Gen[Message] = movementMessageWithStatus.map(_.copy(messageCorrelationId = value))
+    }
+
+    implicit class MessageCorrelationIdOps2(movementMessageWithStatus: Gen[MessageWithoutStatus]) {
+      def msgCorrId(value: Int): Gen[Message] = movementMessageWithStatus.map(_.copy(messageCorrelationId = value))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Added message summary endpoint. Includes:

IE015
IE016
IE028

Additional endpoints will need adding for other messages (this PR will allow us to pull back correct messages for building TAD)