### PR TITLE
CTDA-1294 Filter messages by received timestamp

### DIFF
--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -40,6 +40,7 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.xml.NodeSeq
+import java.time.OffsetDateTime
 
 class MessagesController @Inject()(
   cc: ControllerComponents,
@@ -99,12 +100,13 @@ class MessagesController @Inject()(
 
     }
 
-  def getMessages(departureId: DepartureId): Action[AnyContent] =
+  def getMessages(departureId: DepartureId, receivedSince: Option[OffsetDateTime]): Action[AnyContent] =
     withMetricsTimerAction("get-all-departure-messages") {
       authenticateForRead(departureId) {
         implicit request =>
-          messagesCount.update(request.departure.messages.length)
-          Ok(Json.toJsObject(ResponseDepartureWithMessages.build(request.departure)))
+          val response = ResponseDepartureWithMessages.build(request.departure, receivedSince)
+          messagesCount.update(response.messages.length)
+          Ok(Json.toJsObject(response))
       }
     }
 

--- a/app/models/Message.scala
+++ b/app/models/Message.scala
@@ -24,6 +24,8 @@ import utils.XmlToJson
 
 import scala.xml.NodeSeq
 import play.api.libs.functional.syntax._
+import java.time.ZoneOffset
+import java.time.OffsetDateTime
 
 sealed trait Message {
   def dateTime: LocalDateTime
@@ -32,6 +34,9 @@ sealed trait Message {
   def messageJson: JsObject
 
   def optStatus: Option[MessageStatus]
+
+  def receivedBefore(requestedDate: OffsetDateTime): Boolean =
+    dateTime.atOffset(ZoneOffset.UTC).isBefore(requestedDate)
 }
 
 final case class MessageWithStatus(dateTime: LocalDateTime,

--- a/app/models/response/ResponseDepartureWithMessages.scala
+++ b/app/models/response/ResponseDepartureWithMessages.scala
@@ -26,6 +26,7 @@ import models.DepartureStatus
 import models.MovementReferenceNumber
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
+import java.time.OffsetDateTime
 
 case class ResponseDepartureWithMessages(departureId: DepartureId,
                                          location: String,
@@ -39,7 +40,7 @@ case class ResponseDepartureWithMessages(departureId: DepartureId,
 
 object ResponseDepartureWithMessages {
 
-  def build(departure: Departure): ResponseDepartureWithMessages =
+  def build(departure: Departure, receivedSince: Option[OffsetDateTime]): ResponseDepartureWithMessages =
     ResponseDepartureWithMessages(
       departure.departureId,
       routes.DeparturesController.get(departure.departureId).url,
@@ -51,7 +52,10 @@ object ResponseDepartureWithMessages {
       departure.updated,
       departure.messagesWithId
         .filterNot {
-          case (message, _) => message.optStatus == Some(SubmissionFailed)
+          case (message, _) =>
+            val failedMessage            = message.optStatus == Some(SubmissionFailed)
+            lazy val beforeRequestedDate = receivedSince.fold(false)(message.receivedBefore)
+            failedMessage || beforeRequestedDate
         }
         .map {
           case (message, messageId) => ResponseMessage.build(departure.departureId, messageId, message)

--- a/build.sbt
+++ b/build.sbt
@@ -20,19 +20,19 @@ lazy val microservice = Project(appName, file("."))
   .settings(scalacSettings)
   .settings(
     majorVersion := 0,
-    scalaVersion := "2.12.11",
+    scalaVersion := "2.12.13",
     resolvers += Resolver.jcenterRepo,
     PlayKeys.playDefaultPort := 9490,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
-    // Import models by default in route files
-    RoutesKeys.routesImport ++= Seq(
-      "models._"
-    ),
     javaOptions ++= Seq(
       "-Djdk.xml.maxOccurLimit=10000"
     ),
     // Import models for query string binding in routes file
-    RoutesKeys.routesImport ++= Seq("models._", "models.Binders._", "java.time.OffsetDateTime")
+    RoutesKeys.routesImport ++= Seq(
+      "models._",
+      "models.Binders._",
+      "java.time.OffsetDateTime"
+    )
   )
 
 // Settings for the whole build
@@ -52,10 +52,9 @@ lazy val scalacSettings = Def.settings(
   Test / scalacOptions ~= {
     opts =>
       opts.filterNot(Set("-Ywarn-dead-code"))
-  }
-  // Cannot be enabled yet - requires Scala 2.12.13 which suffers from https://github.com/scoverage/scalac-scoverage-plugin/issues/305
+  },
   // Disable warnings arising from generated routing code
-  // scalacOptions += "-Wconf:src=routes/.*:silent",
+  scalacOptions += "-Wconf:src=routes/.*:silent"
 )
 
 // Scoverage exclusions and minimums
@@ -83,23 +82,7 @@ lazy val itSettings = Def.settings(
   javaOptions ++= Seq(
     "-Dconfig.resource=it.application.conf",
     "-Dlogger.resource=it.logback.xml"
-  ),
-  // sbt-settings does not cause javaOptions to be passed to test groups by default
-  // needed unless / until this PR is merged and released: https://github.com/hmrc/sbt-settings/pull/19/files
-  testGrouping := {
-    val tests          = (IntegrationTest / definedTests).value
-    val forkJvmOptions = (IntegrationTest / javaOptions).value
-    tests.map {
-      test =>
-        Group(
-          test.name,
-          Seq(test),
-          SubProcess(
-            ForkOptions().withRunJVMOptions(forkJvmOptions.toVector :+ ("-Dtest.name=" + test.name))
-          )
-        )
-    }
-  }
+  )
 )
 
 lazy val testSettings = Def.settings(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,7 +7,7 @@ GET        /movements/departures/:departureId                                   
 
 
 GET        /movements/departures/:departureId/messages/summary                  controllers.MessagesSummaryController.messagesSummary(departureId: DepartureId)
-GET        /movements/departures/:departureId/messages                          controllers.MessagesController.getMessages(departureId: DepartureId)
+GET        /movements/departures/:departureId/messages                          controllers.MessagesController.getMessages(departureId: DepartureId, receivedSince: Option[OffsetDateTime] ?= None)
 POST       /movements/departures/:departureId/messages                          controllers.MessagesController.post(departureId: DepartureId)
 
 GET        /movements/departures/:departureId/messages/:messageId               controllers.MessagesController.getMessage(departureId: DepartureId, messageId: MessageId)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val catsVersion = "2.4.2"
+  private val catsVersion = "2.5.0"
 
   val compile = Seq(
     "org.reactivemongo" %% "play2-reactivemongo"             % "0.20.13-play27",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
@@ -12,7 +12,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.7.0")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
 


### PR DESCRIPTION
Allows users to filter the GET all messages endpoint by received datetime of the message.