### PR TITLE
CTCTRADERS-2761 Change PDF download code to stream data

### DIFF
--- a/app/models/PdfDocument.scala
+++ b/app/models/PdfDocument.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+
+case class PdfDocument(
+  dataSource: Source[ByteString, _],
+  contentLength: Option[Long],
+  contentType: Option[String],
+  contentDisposition: Option[String]
+)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -30,6 +30,7 @@ object AppDependencies {
     "org.typelevel"          %% "cats-laws"            % catsVersion,
     "org.typelevel"          %% "discipline-core"      % "1.1.5",
     "org.typelevel"          %% "discipline-scalatest" % "2.1.5",
-    "com.vladsch.flexmark"    % "flexmark-all"         % "0.36.8"
+    "com.vladsch.flexmark"    % "flexmark-all"         % "0.36.8",
+    "com.typesafe.akka"      %% "akka-stream-testkit"  % "2.5.31"
   ).map(_ % "test, it")
 }

--- a/test/connectors/ManageDocumentsConnectorSpec.scala
+++ b/test/connectors/ManageDocumentsConnectorSpec.scala
@@ -16,7 +16,6 @@
 
 package connectors
 
-import akka.util.ByteString
 import com.github.tomakehurst.wiremock.client.WireMock._
 import generators.ModelGenerators
 import org.scalacheck.Gen
@@ -35,6 +34,7 @@ import uk.gov.hmrc.http.RequestId
 
 import scala.concurrent.Future
 import scala.xml.Elem
+import models.PdfDocument
 
 class ManageDocumentsConnectorSpec
     extends AnyFreeSpec
@@ -86,7 +86,7 @@ class ManageDocumentsConnectorSpec
         running(app) {
           val connector = app.injector.instanceOf[ManageDocumentsConnector]
 
-          val result: Future[Either[TADErrorResponse, (ByteString, Map[String, Seq[String]])]] = connector.getTadPDF(releasedForTransitXml)
+          val result: Future[Either[TADErrorResponse, PdfDocument]] = connector.getTadPDF(releasedForTransitXml)
           result.futureValue.isRight mustBe true
         }
       }
@@ -113,7 +113,7 @@ class ManageDocumentsConnectorSpec
         running(app) {
           val connector = app.injector.instanceOf[ManageDocumentsConnector]
 
-          val result: Future[Either[TADErrorResponse, (ByteString, Map[String, Seq[String]])]] = connector.getTadPDF(releasedForTransitXml)
+          val result: Future[Either[TADErrorResponse, PdfDocument]] = connector.getTadPDF(releasedForTransitXml)
           result.futureValue mustBe Left(UnexpectedResponse(genErrorResponse))
         }
       }
@@ -142,7 +142,7 @@ class ManageDocumentsConnectorSpec
         running(app) {
           val connector = app.injector.instanceOf[ManageDocumentsConnector]
 
-          val result: Future[Either[TADErrorResponse, (ByteString, Map[String, Seq[String]])]] = connector.getTsadPDF(releasedForTransitXml)
+          val result: Future[Either[TADErrorResponse, PdfDocument]] = connector.getTsadPDF(releasedForTransitXml)
           result.futureValue.isRight mustBe true
         }
       }
@@ -169,7 +169,7 @@ class ManageDocumentsConnectorSpec
         running(app) {
           val connector = app.injector.instanceOf[ManageDocumentsConnector]
 
-          val result: Future[Either[TADErrorResponse, (ByteString, Map[String, Seq[String]])]] = connector.getTsadPDF(releasedForTransitXml)
+          val result: Future[Either[TADErrorResponse, PdfDocument]] = connector.getTsadPDF(releasedForTransitXml)
           result.futureValue mustBe Left(UnexpectedResponse(genErrorResponse))
         }
       }

--- a/test/services/PDFRetrievalServiceSpec.scala
+++ b/test/services/PDFRetrievalServiceSpec.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import base.SpecBase
 import cats.data.NonEmptyList
@@ -27,6 +28,7 @@ import models.DepartureStatus
 import models.MessageId
 import models.MessageType
 import models.MessageWithoutStatus
+import models.PdfDocument
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito.reset
@@ -87,14 +89,11 @@ class PDFRetrievalServiceSpec extends SpecBase with JsonHelper with IntegrationP
                                      convertXmlToJson(<blank2></blank2>.toString())))
             )
 
-          val headers = Map("Content-Disposition" -> Seq("value"), "Content-Type" -> Seq("value"), "OtherHeader" -> Seq("value"))
+          val pdfDocument = PdfDocument(Source.single(ByteString("Hello".getBytes())), None, Some("value"), Some("value"))
 
-          when(mockManageDocumentsConnector.getTadPDF(eqTo(<blank2></blank2>))(any()))
-            .thenReturn(Future.successful(Right((ByteString("Hello".getBytes()), headers))))
+          when(mockManageDocumentsConnector.getTadPDF(eqTo(<blank2></blank2>))(any())).thenReturn(Future.successful(Right(pdfDocument)))
 
-          val expectedHeaders = Seq(("Content-Disposition", "value"), ("Content-Type", "value"))
-
-          service.getAccompanyingDocumentPDF(departure).futureValue mustBe Right((ByteString("Hello".getBytes()), expectedHeaders))
+          service.getAccompanyingDocumentPDF(departure).futureValue mustBe Right(pdfDocument)
 
           verify(mockManageDocumentsConnector, times(0)).getTsadPDF(any())(any())
           verify(mockManageDocumentsConnector, times(1)).getTadPDF(eqTo(<blank2></blank2>))(any())
@@ -112,14 +111,11 @@ class PDFRetrievalServiceSpec extends SpecBase with JsonHelper with IntegrationP
                                      convertXmlToJson(<blank2></blank2>.toString())))
             )
 
-          val headers = Map("Content-Disposition" -> Seq("value"), "Content-Type" -> Seq("value"), "OtherHeader" -> Seq("value"))
+          val pdfDocument = PdfDocument(Source.single(ByteString("Hello".getBytes())), None, Some("value"), Some("value"))
 
-          when(mockManageDocumentsConnector.getTadPDF(eqTo(safetyXML(0)))(any()))
-            .thenReturn(Future.successful(Right((ByteString("Hello".getBytes()), headers))))
+          when(mockManageDocumentsConnector.getTadPDF(eqTo(safetyXML(0)))(any())).thenReturn(Future.successful(Right(pdfDocument)))
 
-          val expectedHeaders = Seq(("Content-Disposition", "value"), ("Content-Type", "value"))
-
-          service.getAccompanyingDocumentPDF(departure).futureValue mustBe Right((ByteString("Hello".getBytes()), expectedHeaders))
+          service.getAccompanyingDocumentPDF(departure).futureValue mustBe Right(pdfDocument)
 
           verify(mockManageDocumentsConnector, times(0)).getTsadPDF(any())(any())
           verify(mockManageDocumentsConnector, times(1)).getTadPDF(eqTo(safetyXML(0)))(any())
@@ -184,14 +180,11 @@ class PDFRetrievalServiceSpec extends SpecBase with JsonHelper with IntegrationP
           when(mockMessageRetrievalService.getReleaseForTransitMessage(eqTo(departure)))
             .thenReturn(Some(MessageWithoutStatus(MessageId(2), LocalDateTime.now, MessageType.ReleaseForTransit, xml, 2, convertXmlToJson(xml.toString()))))
 
-          val headers = Map("Content-Disposition" -> Seq("value"), "Content-Type" -> Seq("value"), "OtherHeader" -> Seq("value"))
+          val pdfDocument = PdfDocument(Source.single(ByteString("Hello".getBytes())), Some(5L), Some("value"), Some("value"))
 
-          when(mockManageDocumentsConnector.getTsadPDF(eqTo(xml))(any()))
-            .thenReturn(Future.successful(Right((ByteString("Hello".getBytes()), headers))))
+          when(mockManageDocumentsConnector.getTsadPDF(eqTo(xml))(any())).thenReturn(Future.successful(Right(pdfDocument)))
 
-          val expectedHeaders = Seq(("Content-Disposition", "value"), ("Content-Type", "value"))
-
-          service.getAccompanyingDocumentPDF(departure).futureValue mustBe Right((ByteString("Hello".getBytes()), expectedHeaders))
+          service.getAccompanyingDocumentPDF(departure).futureValue mustBe Right(pdfDocument)
 
           verify(mockManageDocumentsConnector, times(1))
             .getTsadPDF(eqTo(xml))(any())


### PR DESCRIPTION
I think this is only the first part of the memory usage issues that we have with this endpoint - the other half is in the code which fetches all of the movement messages in order to get the latest unloading permission message XML.