### PR TITLE
CTDA 1684: Add audit type and method for missing movements

### DIFF
--- a/app/audit/AuditType.scala
+++ b/app/audit/AuditType.scala
@@ -29,7 +29,8 @@ object AuditType extends Enumerable.Implicits {
   case object DepartureCancellationRequestSubmitted extends AuditType
 
   // Error
-  case object MissingMovementRequested extends AuditType
+  case object CustomerRequestedMissingMovement extends AuditType
+  case object NCTSRequestedMissingMovement     extends AuditType
 
   //Transform
   case object MesSenMES3Added extends AuditType
@@ -50,7 +51,8 @@ object AuditType extends Enumerable.Implicits {
     Seq(
       DepartureDeclarationSubmitted,
       DepartureCancellationRequestSubmitted,
-      MissingMovementRequested,
+      CustomerRequestedMissingMovement,
+      NCTSRequestedMissingMovement,
       PositiveAcknowledgementReceived,
       MrnAllocatedReceived,
       DeclarationRejectedReceived,

--- a/app/audit/AuditType.scala
+++ b/app/audit/AuditType.scala
@@ -28,6 +28,9 @@ object AuditType extends Enumerable.Implicits {
   case object DepartureDeclarationSubmitted         extends AuditType
   case object DepartureCancellationRequestSubmitted extends AuditType
 
+  // Error
+  case object MissingMovementRequested extends AuditType
+
   //Transform
   case object MesSenMES3Added extends AuditType
 
@@ -47,6 +50,7 @@ object AuditType extends Enumerable.Implicits {
     Seq(
       DepartureDeclarationSubmitted,
       DepartureCancellationRequestSubmitted,
+      MissingMovementRequested,
       PositiveAcknowledgementReceived,
       MrnAllocatedReceived,
       DeclarationRejectedReceived,

--- a/app/controllers/actions/AuthenticatedGetDepartureWithMessagesAction.scala
+++ b/app/controllers/actions/AuthenticatedGetDepartureWithMessagesAction.scala
@@ -58,7 +58,7 @@ private[actions] class AuthenticatedGetDepartureWithMessagesAction(
           logger.warn("Attempt to retrieve an departure for another EORI")
           Left(NotFound)
         case None =>
-          auditService.auditMissingMovementEvent(request, departureId)
+          auditService.auditCustomerRequestedMissingMovementEvent(request, departureId)
           Left(NotFound)
       }
       .recover {

--- a/app/controllers/actions/AuthenticatedGetDepartureWithoutMessagesAction.scala
+++ b/app/controllers/actions/AuthenticatedGetDepartureWithoutMessagesAction.scala
@@ -58,7 +58,7 @@ private[actions] class AuthenticatedGetDepartureWithoutMessagesAction(
           logger.warn("Attempt to retrieve an departure for another EORI")
           Left(NotFound)
         case None =>
-          auditService.auditMissingMovementEvent(request, departureId)
+          auditService.auditCustomerRequestedMissingMovementEvent(request, departureId)
           Left(NotFound)
       }
       .recover {

--- a/app/controllers/actions/AuthenticatedGetDepartureWithoutMessagesAction.scala
+++ b/app/controllers/actions/AuthenticatedGetDepartureWithoutMessagesAction.scala
@@ -16,6 +16,7 @@
 
 package controllers.actions
 
+import audit.AuditService
 import models.DepartureId
 import models.request.AuthenticatedRequest
 import models.request.DepartureWithoutMessagesRequest
@@ -31,16 +32,18 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 private[actions] class AuthenticatedGetDepartureWithoutMessagesActionProvider @Inject()(
-  repository: DepartureRepository
+  repository: DepartureRepository,
+  auditService: AuditService
 )(implicit ec: ExecutionContext) {
 
   def apply(departureId: DepartureId): ActionRefiner[AuthenticatedRequest, DepartureWithoutMessagesRequest] =
-    new AuthenticatedGetDepartureWithoutMessagesAction(departureId, repository)
+    new AuthenticatedGetDepartureWithoutMessagesAction(departureId, repository, auditService)
 }
 
 private[actions] class AuthenticatedGetDepartureWithoutMessagesAction(
   departureId: DepartureId,
-  repository: DepartureRepository
+  repository: DepartureRepository,
+  auditService: AuditService
 )(implicit val executionContext: ExecutionContext)
     extends ActionRefiner[AuthenticatedRequest, DepartureWithoutMessagesRequest]
     with Logging {
@@ -55,6 +58,7 @@ private[actions] class AuthenticatedGetDepartureWithoutMessagesAction(
           logger.warn("Attempt to retrieve an departure for another EORI")
           Left(NotFound)
         case None =>
+          auditService.auditMissingMovementEvent(request, departureId)
           Left(NotFound)
       }
       .recover {

--- a/app/models/ChannelType.scala
+++ b/app/models/ChannelType.scala
@@ -21,9 +21,8 @@ sealed abstract class ChannelType(name: String) {
 }
 
 object ChannelType extends Enumerable.Implicits {
-  object Web     extends ChannelType("web")
-  object Api     extends ChannelType("api")
-  object Deleted extends ChannelType("deleted")
+  object Web extends ChannelType("web")
+  object Api extends ChannelType("api")
 
   val values: Seq[ChannelType] = Seq(Web, Api)
 

--- a/test/controllers/actions/AuthenticateGetDepartureWithMessagesForReadActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticateGetDepartureWithMessagesForReadActionProviderSpec.scala
@@ -185,7 +185,7 @@ class AuthenticateGetDepartureWithMessagesForReadActionProviderSpec
         val result     = controller.get(departureId)(fakeRequest)
 
         status(result) mustBe NOT_FOUND
-        verify(mockAuditService, times(1)).auditMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(departureId))
+        verify(mockAuditService, times(1)).auditCustomerRequestedMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(departureId))
       }
 
       "must return Not Found when the departure exists but does not share the channel" in {

--- a/test/controllers/actions/AuthenticateGetDepartureWithMessagesForReadActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticateGetDepartureWithMessagesForReadActionProviderSpec.scala
@@ -24,6 +24,8 @@ import models.ChannelType.Web
 import models.Departure
 import models.DepartureId
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.OptionValues
@@ -49,6 +51,8 @@ import uk.gov.hmrc.auth.core.EnrolmentIdentifier
 import uk.gov.hmrc.auth.core.Enrolments
 
 import scala.concurrent.Future
+import audit.AuditService
+import models.request.AuthenticatedRequest
 
 class AuthenticateGetDepartureWithMessagesForReadActionProviderSpec
     extends AnyFreeSpec
@@ -155,12 +159,13 @@ class AuthenticateGetDepartureWithMessagesForReadActionProviderSpec
         status(result) mustBe NOT_FOUND
       }
 
-      "must return Not Found when the departure does not exist" in {
+      "must return Not Found and audit when the departure does not exist" in {
 
         val departureId = arbitrary[DepartureId].sample.value
 
         val mockAuthConnector: AuthConnector = mock[AuthConnector]
         val mockDepartureRepository          = mock[DepartureRepository]
+        val mockAuditService: AuditService   = mock[AuditService]
 
         when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
           .thenReturn(Future.successful(validEnrolments))
@@ -170,7 +175,8 @@ class AuthenticateGetDepartureWithMessagesForReadActionProviderSpec
           .overrides(
             bind[DepartureRepository].toInstance(mockDepartureRepository),
             bind[AuthConnector].toInstance(mockAuthConnector),
-            bind[MigrationRunner].to[FakeMigrationRunner]
+            bind[MigrationRunner].to[FakeMigrationRunner],
+            bind[AuditService].toInstance(mockAuditService)
           )
 
         val actionProvider = application.injector().instanceOf[AuthenticatedGetDepartureWithMessagesForReadActionProvider]
@@ -179,6 +185,7 @@ class AuthenticateGetDepartureWithMessagesForReadActionProviderSpec
         val result     = controller.get(departureId)(fakeRequest)
 
         status(result) mustBe NOT_FOUND
+        verify(mockAuditService, times(1)).auditMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(departureId))
       }
 
       "must return Not Found when the departure exists but does not share the channel" in {

--- a/test/controllers/actions/AuthenticateGetDepartureWithoutMessagesForReadActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticateGetDepartureWithoutMessagesForReadActionProviderSpec.scala
@@ -181,7 +181,7 @@ class AuthenticateGetDepartureWithoutMessagesForReadActionProviderSpec
         val result     = controller.get(departureId)(fakeRequest)
 
         status(result) mustBe NOT_FOUND
-        verify(mockAuditService, times(1)).auditMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(departureId))
+        verify(mockAuditService, times(1)).auditCustomerRequestedMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(departureId))
       }
 
       "must return Not Found when the departure exists but does not share the channel" in {

--- a/test/services/DepartureRetrievalServiceSpec.scala
+++ b/test/services/DepartureRetrievalServiceSpec.scala
@@ -102,7 +102,7 @@ class DepartureRetrievalServiceSpec extends SpecBase {
         .mustBe(Left(DepartureNotFound(s"[GetDepartureService][getDepartureById] Unable to retrieve departure message for arrival id: ${departureId.index}")))
 
       verify(mockRepo).get(eqTo(departureId))
-      verify(mockAuditService).auditNCTSMessages(eqTo(ChannelType.Deleted), eqTo("Deleted"), eqTo(MrnAllocatedResponse), eqTo(node))(any())
+      verify(mockAuditService).auditNCTSRequestedMissingMovementEvent(eqTo(departureId), eqTo(MrnAllocatedResponse), eqTo(node))(any())
     }
   }
 }


### PR DESCRIPTION
If a departure ID does not return a movement, audit it.

(Not a huge fan of the name of the audit type, so open to suggestions)

Also includes header updates in a separate commit which can be removed if another PR gets there first.

Also see https://github.com/hmrc/transit-movements-trader-at-destination/pull/274