### PR TITLE
CTDA-1935: Automatically update TTL based on configuration

### DIFF
--- a/app/logging/LoggerName.scala
+++ b/app/logging/LoggerName.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+private[logging] trait LoggerName {
+
+  final val loggerName = s"application.${this.getClass.getCanonicalName}"
+
+}

--- a/app/logging/Logging.scala
+++ b/app/logging/Logging.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import play.api.Logger
+
+trait Logging extends LoggerName {
+
+  final val logger: Logger = Logger(loggerName)
+
+}

--- a/app/logging/StreamLogging.scala
+++ b/app/logging/StreamLogging.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import akka.actor.ActorSystem
+import akka.event.{Logging => AkkaEventLogging}
+import akka.event.LoggingAdapter
+
+trait StreamLoggerAdapter extends LoggerName {
+
+  implicit def adapter(implicit actorSystem: ActorSystem): LoggingAdapter =
+    AkkaEventLogging(actorSystem, loggerName)
+
+}

--- a/app/repositories/DepartureRepository.scala
+++ b/app/repositories/DepartureRepository.scala
@@ -20,6 +20,7 @@ import cats.data.Ior
 import cats.syntax.all._
 import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
+import logging.Logging
 import metrics.HasMetrics
 import models._
 import models.response.ResponseDeparture
@@ -57,6 +58,7 @@ class DepartureRepository @Inject()(
 )(implicit ec: ExecutionContext, clock: Clock)
     extends MongoDateTimeFormats
     with HasMetrics
+    with Logging
     with Repository {
 
   private lazy val eoriNumberIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
@@ -74,9 +76,10 @@ class DepartureRepository @Inject()(
     name = Some("reference-number-index")
   )
 
+  private lazy val lastUpdatedIndexName = "last-updated-index"
   private lazy val lastUpdatedIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
     key = Seq("lastUpdated" -> IndexType.Ascending),
-    name = Some("last-updated-index"),
+    name = Some(lastUpdatedIndexName),
     options = BSONDocument("expireAfterSeconds" -> appConfig.cacheTtl)
   )
 
@@ -95,6 +98,7 @@ class DepartureRepository @Inject()(
       .flatMap {
         jsonCollection =>
           for {
+            _   <- dropLastUpdatedIndex(jsonCollection)
             _   <- jsonCollection.indexesManager.ensure(channelIndex)
             _   <- jsonCollection.indexesManager.ensure(eoriNumberIndex)
             _   <- jsonCollection.indexesManager.ensure(referenceNumberIndex)
@@ -107,7 +111,7 @@ class DepartureRepository @Inject()(
         _ => ()
       )
 
-  private lazy val collectionName = DepartureRepository.collectionName
+  lazy val collectionName = DepartureRepository.collectionName
 
   private def collection: Future[JSONCollection] =
     mongo.database.map(_.collection[JSONCollection](collectionName))
@@ -554,6 +558,29 @@ class DepartureRepository @Inject()(
         }
     }
   }
+
+  private def dropLastUpdatedIndex(collection: JSONCollection): Future[Boolean] =
+    collection.indexesManager.list.flatMap {
+      indexes =>
+        val indexToDrop = indexes
+          .filter(_.name.contains(lastUpdatedIndexName))
+          .filter(x => x.expireAfterSeconds.map(_ != appConfig.cacheTtl).getOrElse(false))
+          .get(0)
+        indexToDrop match {
+          case Some(index) =>
+            val ttl = index.expireAfterSeconds.map(x => s"$x seconds").getOrElse("unset")
+            logger.warn(s"Dropping $lastUpdatedIndexName index with TTL $ttl")
+
+            collection.indexesManager
+              .drop(lastUpdatedIndexName)
+              .map(
+                _ => true
+              )
+          case None =>
+            logger.info(s"$lastUpdatedIndexName does not exist or is currently valid")
+            Future.successful(true)
+        }
+    }
 }
 
 object DepartureRepository {

--- a/app/repositories/DepartureRepository.scala
+++ b/app/repositories/DepartureRepository.scala
@@ -565,7 +565,7 @@ class DepartureRepository @Inject()(
         val indexToDrop = indexes
           .filter(_.name.contains(lastUpdatedIndexName))
           .filter(x => x.expireAfterSeconds.map(_ != appConfig.cacheTtl).getOrElse(false))
-          .get(0)
+          .headOption
         indexToDrop match {
           case Some(index) =>
             val ttl = index.expireAfterSeconds.map(x => s"$x seconds").getOrElse("unset")

--- a/test/audit/AuditServiceSpec.scala
+++ b/test/audit/AuditServiceSpec.scala
@@ -278,7 +278,7 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
           "totalNoOfContainers"              -> 0,
           "totalNoOfCountriesOfRouting"      -> 0,
           "requestLength"                    -> requestLength
-        )
+      )
 
       Seq(arbitraryBox.arbitrary.sample, None).foreach {
         boxOpt =>

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -69,7 +69,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with MockitoSugar with ScalaFut
         normalisedA == normalisedX
 
       case _ => false
-    }
+  }
 
   implicit val departureEquality: Equality[Departure] = (a: Departure, b: Any) =>
     b match {
@@ -91,5 +91,5 @@ trait SpecBase extends AnyFreeSpec with Matchers with MockitoSugar with ScalaFut
 
         normalisedA == normalisedX
       case _ => false
-    }
+  }
 }

--- a/test/controllers/actions/FakeAuthenticateActionProvider.scala
+++ b/test/controllers/actions/FakeAuthenticateActionProvider.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class FakeAuthenticateActionProvider @Inject() (defaultActionBuilder: DefaultActionBuilder, auth: FakeAuthenticateAction)() extends AuthenticateActionProvider {
+class FakeAuthenticateActionProvider @Inject()(defaultActionBuilder: DefaultActionBuilder, auth: FakeAuthenticateAction)() extends AuthenticateActionProvider {
 
   override def apply(): ActionBuilder[AuthenticatedRequest, AnyContent] =
     defaultActionBuilder andThen auth

--- a/test/generators/BaseGenerators.scala
+++ b/test/generators/BaseGenerators.scala
@@ -39,12 +39,13 @@ trait BaseGenerators {
     for {
       seq1 <- gen
       seq2 <- Gen.listOfN(seq1.length, genValue)
-    } yield seq1.toSeq.zip(seq2).foldRight("") {
-      case ((n, Some(v)), m) =>
-        m + n + v
-      case ((n, _), m) =>
-        m + n
-    }
+    } yield
+      seq1.toSeq.zip(seq2).foldRight("") {
+        case ((n, Some(v)), m) =>
+          m + n + v
+        case ((n, _), m) =>
+          m + n
+      }
   }
 
   def intsInRangeWithCommas(min: Int, max: Int): Gen[String] = {

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -164,19 +164,20 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators with JsonHe
         lastUpdated     <- arbitrary[LocalDateTime]
         messageMetaData <- nonEmptyListOfMaxLength[MessageMetaData](2)
         notificationBox <- arbitrary[Option[Box]]
-      } yield DepartureWithoutMessages(
-        id,
-        channel,
-        eN,
-        mrn,
-        rN,
-        created,
-        lastUpdated,
-        notificationBox,
-        MessageId(messageMetaData.length + 1),
-        messageMetaData.length + 1,
-        messageMetaData.toList
-      )
+      } yield
+        DepartureWithoutMessages(
+          id,
+          channel,
+          eN,
+          mrn,
+          rN,
+          created,
+          lastUpdated,
+          notificationBox,
+          MessageId(messageMetaData.length + 1),
+          messageMetaData.length + 1,
+          messageMetaData.toList
+        )
     }
 
   implicit lazy val arbitraryFailure: Arbitrary[SubmissionFailure] =

--- a/test/migrations/MovementsChangeLogSpec.scala
+++ b/test/migrations/MovementsChangeLogSpec.scala
@@ -68,37 +68,38 @@ class MovementsChangeLogSpec extends SpecBase with IntegrationPatience with Befo
 
       _ <- coll.insert.many {
         for (id <- departureIds)
-          yield Json.obj(
-            "_id"                      -> id.index,
-            "channel"                  -> ChannelType.Web.toString,
-            "eoriNumber"               -> eori,
-            "referenceNumber"          -> Random.alphanumeric.take(20).mkString,
-            "status"                   -> DepartureStatus.DepartureSubmitted.toString,
-            "created"                  -> LocalDateTime.of(2021, 7, 15, 12, 12),
-            "lastUpdated"              -> LocalDateTime.of(2021, 7, 15, 12, 13),
-            "nextMessageCorrelationId" -> 2,
-            "messages" -> Json.arr(
-              Json.obj(
-                "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 12),
-                "messageType"          -> MessageType.DepartureDeclaration.toString,
-                "message"              -> NodeSeq.fromSeq(Seq(<CC015B></CC015B>)),
-                "status"               -> MessageStatus.SubmissionSucceeded.toString,
-                "messageCorrelationId" -> 1
-              ),
-              Json.obj(
-                "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 12),
-                "messageType"          -> MessageType.PositiveAcknowledgement.toString,
-                "message"              -> NodeSeq.fromSeq(Seq(<CC928A></CC928A>)),
-                "messageCorrelationId" -> 1
-              ),
-              Json.obj(
-                "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 13),
-                "messageType"          -> MessageType.MrnAllocated.toString,
-                "message"              -> NodeSeq.fromSeq(Seq(<CC028A></CC028A>)),
-                "messageCorrelationId" -> 1
+          yield
+            Json.obj(
+              "_id"                      -> id.index,
+              "channel"                  -> ChannelType.Web.toString,
+              "eoriNumber"               -> eori,
+              "referenceNumber"          -> Random.alphanumeric.take(20).mkString,
+              "status"                   -> DepartureStatus.DepartureSubmitted.toString,
+              "created"                  -> LocalDateTime.of(2021, 7, 15, 12, 12),
+              "lastUpdated"              -> LocalDateTime.of(2021, 7, 15, 12, 13),
+              "nextMessageCorrelationId" -> 2,
+              "messages" -> Json.arr(
+                Json.obj(
+                  "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 12),
+                  "messageType"          -> MessageType.DepartureDeclaration.toString,
+                  "message"              -> NodeSeq.fromSeq(Seq(<CC015B></CC015B>)),
+                  "status"               -> MessageStatus.SubmissionSucceeded.toString,
+                  "messageCorrelationId" -> 1
+                ),
+                Json.obj(
+                  "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 12),
+                  "messageType"          -> MessageType.PositiveAcknowledgement.toString,
+                  "message"              -> NodeSeq.fromSeq(Seq(<CC928A></CC928A>)),
+                  "messageCorrelationId" -> 1
+                ),
+                Json.obj(
+                  "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 13),
+                  "messageType"          -> MessageType.MrnAllocated.toString,
+                  "message"              -> NodeSeq.fromSeq(Seq(<CC028A></CC028A>)),
+                  "messageCorrelationId" -> 1
+                )
               )
             )
-          )
       }
     } yield ()
 

--- a/test/models/MessageTypeSpec.scala
+++ b/test/models/MessageTypeSpec.scala
@@ -373,12 +373,12 @@ class MessageTypeSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with 
         "GuaranteeNotValid, " +
         "ReleaseForTransit" in {
 
-          forAll(Gen.oneOf(lesserOrderValues)) {
-            status =>
-              Ordering[MessageType].max(DeclarationCancellationRequest, status) mustBe DeclarationCancellationRequest
-              Ordering[MessageType].max(status, DeclarationCancellationRequest) mustBe DeclarationCancellationRequest
-          }
+        forAll(Gen.oneOf(lesserOrderValues)) {
+          status =>
+            Ordering[MessageType].max(DeclarationCancellationRequest, status) mustBe DeclarationCancellationRequest
+            Ordering[MessageType].max(status, DeclarationCancellationRequest) mustBe DeclarationCancellationRequest
         }
+      }
 
       "in lesser order than any other status" in {
 
@@ -421,12 +421,12 @@ class MessageTypeSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with 
         "XMLSubmissionNegativeAcknowledgement ," +
         "DeclarationCancellationRequest" in {
 
-          forAll(Gen.oneOf(lesserOrderValues)) {
-            status =>
-              Ordering[MessageType].max(CancellationDecision, status) mustBe CancellationDecision
-              Ordering[MessageType].max(status, CancellationDecision) mustBe CancellationDecision
-          }
+        forAll(Gen.oneOf(lesserOrderValues)) {
+          status =>
+            Ordering[MessageType].max(CancellationDecision, status) mustBe CancellationDecision
+            Ordering[MessageType].max(status, CancellationDecision) mustBe CancellationDecision
         }
+      }
 
       "in lesser order than any other status" in {
 
@@ -460,12 +460,12 @@ class MessageTypeSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with 
         "DepartureDeclaration, " +
         "DeclarationCancellationRequest" in {
 
-          forAll(Gen.oneOf(lesserOrderValues)) {
-            status =>
-              Ordering[MessageType].max(XMLSubmissionNegativeAcknowledgement, status) mustBe XMLSubmissionNegativeAcknowledgement
-              Ordering[MessageType].max(status, XMLSubmissionNegativeAcknowledgement) mustBe XMLSubmissionNegativeAcknowledgement
-          }
+        forAll(Gen.oneOf(lesserOrderValues)) {
+          status =>
+            Ordering[MessageType].max(XMLSubmissionNegativeAcknowledgement, status) mustBe XMLSubmissionNegativeAcknowledgement
+            Ordering[MessageType].max(status, XMLSubmissionNegativeAcknowledgement) mustBe XMLSubmissionNegativeAcknowledgement
         }
+      }
 
       "in lesser order than any other status" in {
 

--- a/test/services/MessageRetrievalServiceSpec.scala
+++ b/test/services/MessageRetrievalServiceSpec.scala
@@ -87,7 +87,7 @@ class MessageRetrievalServiceSpec extends SpecBase with JsonHelper {
                     ),
                     MessageId(3)
                   )
-                )
+              )
             )
           )
 

--- a/test/services/SubmitMessageServiceSpec.scala
+++ b/test/services/SubmitMessageServiceSpec.scala
@@ -89,11 +89,12 @@ class SubmitMessageServiceSpec extends SpecBase with JsonHelper with ScalaCheckD
 
   val departureWithOneMessage: Gen[Departure] = for {
     departure <- arbitrary[Departure]
-  } yield departure.copy(
-    eoriNumber = "eori",
-    messages = NonEmptyList.one(movementMessage),
-    nextMessageCorrelationId = movementMessage.messageCorrelationId
-  )
+  } yield
+    departure.copy(
+      eoriNumber = "eori",
+      messages = NonEmptyList.one(movementMessage),
+      nextMessageCorrelationId = movementMessage.messageCorrelationId
+    )
 
   "submit a new message" - {
     "return SubmissionSuccess and set the message status to submitted when the message is successfully saved, submitted" in {


### PR DESCRIPTION
Also see https://github.com/hmrc/transit-movements-trader-at-destination/pull/296

Note that this includes the Logging trait from the destination backend so that this could be a copy/paste of the work from said backend.